### PR TITLE
Demo: using `AddHttpClient` only at the module level works fine.

### DIFF
--- a/OrchardCoreHttpClientTest.Module/CmsHttpClientRequestingDependency.cs
+++ b/OrchardCoreHttpClientTest.Module/CmsHttpClientRequestingDependency.cs
@@ -1,14 +1,14 @@
 using System.Net.Http;
 
-namespace OrchardCoreHttpClientTest.Web
+namespace OrchardCoreHttpClientTest.Module
 {
     public class CmsHttpClientRequestingDependency
     {
-        private readonly HttpClient httpClient;
+        private readonly HttpClient _httpClient;
 
         public CmsHttpClientRequestingDependency(HttpClient httpClient)
         {
-            this.httpClient = httpClient;
+            _httpClient = httpClient;
         }
     }
 }

--- a/OrchardCoreHttpClientTest.Module/Controllers/HttpClientRequestingController.cs
+++ b/OrchardCoreHttpClientTest.Module/Controllers/HttpClientRequestingController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace OrchardCoreHttpClientTest.Module
+{
+    public class HttpClientRequestingController : Controller
+    {
+        private readonly PreviouslyCmsHttpClientRequestingDependency _previouslyCmsHttpClientRequestingDependency;
+        private readonly ModuleHttpClientRequestingDependency _moduleHttpClientRequestingDependency;
+        private readonly ILogger<HttpClientRequestingController> _logger;
+
+        public HttpClientRequestingController(
+            PreviouslyCmsHttpClientRequestingDependency previouslyCmsHttpClientRequestingDependency, 
+            ModuleHttpClientRequestingDependency moduleHttpClientRequestingDependency,
+            ILogger<HttpClientRequestingController> logger)
+        {
+            _previouslyCmsHttpClientRequestingDependency = previouslyCmsHttpClientRequestingDependency;
+            _moduleHttpClientRequestingDependency = moduleHttpClientRequestingDependency;
+            _logger = logger;
+        }
+
+        [HttpGet("test")]
+        public IActionResult Test()
+        {
+            _logger.LogInformation($"{_previouslyCmsHttpClientRequestingDependency.GetType().FullName}, {_moduleHttpClientRequestingDependency.GetType().FullName}");
+            return new OkResult();
+        }
+    }
+}

--- a/OrchardCoreHttpClientTest.Module/PreviouslyCmsHttpClientRequestingDependency.cs
+++ b/OrchardCoreHttpClientTest.Module/PreviouslyCmsHttpClientRequestingDependency.cs
@@ -2,11 +2,11 @@ using System.Net.Http;
 
 namespace OrchardCoreHttpClientTest.Module
 {
-    public class CmsHttpClientRequestingDependency
+    public class PreviouslyCmsHttpClientRequestingDependency
     {
         private readonly HttpClient _httpClient;
 
-        public CmsHttpClientRequestingDependency(HttpClient httpClient)
+        public PreviouslyCmsHttpClientRequestingDependency(HttpClient httpClient)
         {
             _httpClient = httpClient;
         }

--- a/OrchardCoreHttpClientTest.Module/Startup.cs
+++ b/OrchardCoreHttpClientTest.Module/Startup.cs
@@ -7,7 +7,8 @@ namespace OrchardCoreHttpClientTest.Module
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            // this raises a Null Reference Exception
+            // this is fine
+            services.AddHttpClient<CmsHttpClientRequestingDependency>();
             services.AddHttpClient<ModuleHttpClientRequestingDependency>();
         }
     }

--- a/OrchardCoreHttpClientTest.Module/Startup.cs
+++ b/OrchardCoreHttpClientTest.Module/Startup.cs
@@ -1,3 +1,6 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Modules;
 
@@ -8,8 +11,13 @@ namespace OrchardCoreHttpClientTest.Module
         public override void ConfigureServices(IServiceCollection services)
         {
             // this is fine
-            services.AddHttpClient<CmsHttpClientRequestingDependency>();
+            services.AddHttpClient<PreviouslyCmsHttpClientRequestingDependency>();
             services.AddHttpClient<ModuleHttpClientRequestingDependency>();
+        }
+
+        public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+            routes.MapControllers();
         }
     }
 }

--- a/OrchardCoreHttpClientTest.Web/Startup.cs
+++ b/OrchardCoreHttpClientTest.Web/Startup.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OrchardCoreHttpClientTest.Module;
 
 namespace OrchardCoreHttpClientTest.Web
 {
@@ -8,8 +9,6 @@ namespace OrchardCoreHttpClientTest.Web
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            // this is fine
-            services.AddHttpClient<CmsHttpClientRequestingDependency>();
             services.AddOrchardCms();
         }
         

--- a/OrchardCoreHttpClientTest.Web/appsettings.json
+++ b/OrchardCoreHttpClientTest.Web/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "OrchardCoreHttpClientTest": "Information"
+    }
+  }
+}


### PR DESCRIPTION
I'll need to check whether the below dependencies use `AddTypedClient`, as I'm not sure the consequences of moving them to the Module level.

- Application Insights
- Snapshot Collector